### PR TITLE
[codex] Fix scrapers and add container workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git/
+.github/
+.venv/
+__pycache__/
+*.py[cod]
+
+.DS_Store
+.env
+
+*_debug*.html
+sage_debug*.*
+wtamu_debug_page*.html
+
+.streamlit/secrets.toml

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,29 @@
+name: Container smoke test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "requirements-scraper.txt"
+      - "run_scrapers.py"
+      - "utils.py"
+      - "scrapers/**"
+      - "app/**"
+      - ".github/workflows/container.yml"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build scraper image
+        run: docker build -t horizons-aggregator:test .
+
+      - name: Smoke test runner CLI
+        run: docker run --rm horizons-aggregator:test python run_scrapers.py --help
+
+      - name: Smoke test Python syntax
+        run: docker run --rm horizons-aggregator:test python -m compileall run_scrapers.py utils.py scrapers app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+
+.venv/
+.env
+
+.DS_Store
+
+*_debug*.html
+sage_debug*.*
+wtamu_debug_page*.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    JOB_DATA_PATH=/data/latest_jobs.json
+
+WORKDIR /app
+
+COPY requirements-scraper.txt .
+RUN pip install --upgrade pip \
+    && pip install -r requirements-scraper.txt \
+    && playwright install --with-deps chromium
+
+COPY . .
+
+RUN useradd --create-home --shell /usr/sbin/nologin appuser \
+    && mkdir -p /data \
+    && chown -R appuser:appuser /app /data /ms-playwright
+
+USER appuser
+
+VOLUME ["/data"]
+
+CMD ["python", "run_scrapers.py"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A small collection of scrapers + a Streamlit dashboard to aggregate open roles f
   * **BrassRing / Kenexa** (e.g., TTUHSC)
   * **Team Engine** (e.g., Talon/LPE)
   * **Static/SSR career pages** (e.g., Amarillo National Bank)
-* **Runner**: `run_scrapers.py` calls each scraper and writes a combined `data/latest_jobs.json`.
+* **Runner**: `run_scrapers.py` calls each scraper and writes a combined `data/latest_jobs.json`. A single scraper failure is logged as a warning and does not stop the remaining scrapers.
 * **Dashboard**: `dashboard.py` reads `data/latest_jobs.json` and provides a simple UI (search + filters + clickable links).
 * **GitHub Actions** workflow (recommended) to run nightly and refresh data.
 
@@ -53,9 +53,42 @@ python -m playwright install chromium
 Run scrapers and dashboard:
 
 ```bash
-python run_scrapers.py               # writes data/latest_jobs.json
-streamlit run app/streamlit_dashboard.py
+python run_scrapers.py        # writes data/latest_jobs.json
+python run_scrapers.py --dry-run --scrapers disco_inc,sage_oil_vac_board
+streamlit run app/dashboard.py
 ```
+
+Useful runner options:
+
+* `JOB_DATA_PATH=/path/latest_jobs.json python run_scrapers.py` writes to a custom path. `OUTPUT_PATH` is also supported as an alias.
+* `REMOTE_RAW_URL=https://... streamlit run app/dashboard.py` points the dashboard at a remote JSON file without Streamlit secrets.
+* `--scrapers` accepts comma-separated source names, short module names, or full module paths.
+* `--dry-run` runs scrapers and logs the summary without writing JSON.
+* `--fail-on-scraper-error` makes any scraper failure return a non-zero exit code. By default, individual scraper failures are warnings so the scheduled run can continue.
+
+## Container
+
+Build and run the scraper image:
+
+```bash
+docker build -t horizons-aggregator .
+docker run --rm -v "$PWD/data:/data" horizons-aggregator
+```
+
+The image defaults to `JOB_DATA_PATH=/data/latest_jobs.json`, which maps cleanly to a mounted volume today and to a Cloud Run Job plus GCS handoff later. For a container smoke test:
+
+```bash
+docker run --rm horizons-aggregator python run_scrapers.py --dry-run --scrapers disco_inc,sage_oil_vac_board
+```
+
+The Docker image installs `requirements-scraper.txt`, which excludes dashboard-only dependencies such as Streamlit and Pandas. Use `requirements.txt` for local dashboard development.
+
+Expected GCP shape later:
+
+* Cloud Run Job executes this image on a schedule.
+* Cloud Scheduler triggers the job.
+* Scraper output moves from the local JSON file to GCS.
+* The Streamlit app reads the GCS-hosted JSON URL or a small API endpoint instead of GitHub Raw.
 
 ## GitHub Actions (nightly refresh)
 
@@ -129,7 +162,7 @@ jobs:
 * Return UTC timestamps with second precision; omit timezone suffix to match existing data.
 * Prefer stable attributes over brittle classnames (`data-automation-id` > `class` when possible).
 * Keep scrapers idempotent and side-effect free (return data; `run_scrapers.py` handles writing files).
-* Log minimally in CI; avoid noisy prints in production scrapers.
+* Log minimally in CI; avoid noisy prints in production scrapers. The runner emits GitHub Actions warnings when a scraper raises and keeps previous jobs for that source when available.
 
 ## Acknowledgements
 

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -13,12 +14,13 @@ st.set_page_config(
 )
 
 # --- Data locations ---
-DATA_FILE = Path(__file__).parents[1] / "data/latest_jobs.json"  # local fallback (repo file)
+DEFAULT_DATA_FILE = Path(__file__).parents[1] / "data/latest_jobs.json"
+DATA_FILE = Path(os.environ.get("JOB_DATA_PATH") or os.environ.get("OUTPUT_PATH") or DEFAULT_DATA_FILE)
 REQUIRED_COLS = ["title", "company", "salary", "location", "url"]
 
-# Prefer remote raw URL so the app updates without redeploys.
-# Set this in Streamlit secrets: REMOTE_RAW_URL: https://raw.githubusercontent.com/<user>/<repo>/<branch>/data/latest_jobs.json
-REMOTE_RAW_URL = st.secrets.get("REMOTE_RAW_URL", "")
+# Prefer remote raw URL so the app updates without redeploys. In Streamlit Cloud,
+# set this in secrets; in containers, set REMOTE_RAW_URL as an environment variable.
+REMOTE_RAW_URL = st.secrets.get("REMOTE_RAW_URL", os.environ.get("REMOTE_RAW_URL", ""))
 DEFAULT_DATA_MODE = "remote" if REMOTE_RAW_URL else "local"
 
 

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -13,12 +14,13 @@ st.set_page_config(
 )
 
 # --- Data locations ---
-DATA_FILE = Path(__file__).parents[1] / "data/latest_jobs.json"  # local fallback (repo file)
+DEFAULT_DATA_FILE = Path(__file__).parents[1] / "data/latest_jobs.json"
+DATA_FILE = Path(os.environ.get("JOB_DATA_PATH") or os.environ.get("OUTPUT_PATH") or DEFAULT_DATA_FILE)
 REQUIRED_COLS = ["title", "company", "salary", "location", "url"]
 
-# Prefer remote raw URL so the app updates without redeploys.
-# Set this in Streamlit secrets: REMOTE_RAW_URL: https://raw.githubusercontent.com/<user>/<repo>/<branch>/data/latest_jobs.json
-REMOTE_RAW_URL = st.secrets.get("REMOTE_RAW_URL", "")
+# Prefer remote raw URL so the app updates without redeploys. In Streamlit Cloud,
+# set this in secrets; in containers, set REMOTE_RAW_URL as an environment variable.
+REMOTE_RAW_URL = st.secrets.get("REMOTE_RAW_URL", os.environ.get("REMOTE_RAW_URL", ""))
 DEFAULT_DATA_MODE = "remote" if REMOTE_RAW_URL else "local"
 
 

--- a/requirements-scraper.txt
+++ b/requirements-scraper.txt
@@ -1,7 +1,5 @@
 requests>=2.32,<3
 beautifulsoup4>=4.12,<5
-pandas>=2.2,<3
-streamlit>=1.32,<2
 playwright>=1.44,<2
 nest_asyncio>=1.6,<2
 cloudscraper>=1.2,<2

--- a/run_scrapers.py
+++ b/run_scrapers.py
@@ -1,31 +1,182 @@
-from importlib import import_module
-from pathlib import Path
-from utils import load_previous, save_latest
+from __future__ import annotations
 
-SCRAPER_MODULES = [
-    "scrapers.wtamu_board",
-    "scrapers.ttuhsc_board",
-    "scrapers.fmc_board",
-    "scrapers.anb_board",
-    "scrapers.yhmc_board",
-    "scrapers.austin_hose_scraper",
-    "scrapers.sage_oil_vac_board",
-    "scrapers.talon_lpe_board",
-    "scrapers.western_equipment",
-    #"scrapers.disco_inc"
-    # "scrapers.other_board",
+import argparse
+import logging
+import os
+import sys
+import traceback
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any
+
+from utils import DATA_PATH, build_job_id, load_previous_jobs, now_utc_iso_seconds, save_latest
+
+
+logger = logging.getLogger("horizons.scrapers")
+
+
+@dataclass(frozen=True)
+class ScraperSpec:
+    module: str
+    source: str
+
+
+SCRAPERS = [
+    ScraperSpec("scrapers.wtamu_board", "WTAMU"),
+    ScraperSpec("scrapers.ttuhsc_board", "TTUHSC"),
+    ScraperSpec("scrapers.fmc_board", "FMC"),
+    ScraperSpec("scrapers.anb_board", "Amarillo National Bank"),
+    ScraperSpec("scrapers.yhmc_board", "Yellowhouse"),
+    ScraperSpec("scrapers.austin_hose_scraper", "Austin Hose"),
+    ScraperSpec("scrapers.sage_oil_vac_board", "Sage Oil Vac"),
+    ScraperSpec("scrapers.talon_lpe_board", "Talon/LPE"),
+    ScraperSpec("scrapers.western_equipment", "Western Equipment"),
+    ScraperSpec("scrapers.disco_inc", "DISCO Inc."),
 ]
 
-def main() -> None:
-    all_jobs = []
+CORE_FIELDS = ("id", "title", "company", "location", "salary", "url", "scraped_at", "source")
 
-    for mod_path in SCRAPER_MODULES:
-        scraper = import_module(mod_path)
-        all_jobs.extend(scraper.fetch_jobs())
 
+def _configure_logging(verbose: bool = False) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+    )
+
+
+def _warn(message: str) -> None:
+    logger.warning(message)
+    if os.environ.get("GITHUB_ACTIONS", "").lower() == "true":
+        print(f"::warning::{message}", file=sys.stderr)
+
+
+def _previous_jobs_for_source(previous: list[dict[str, Any]], source: str) -> list[dict[str, Any]]:
+    return [job for job in previous if job.get("source") == source]
+
+
+def _normalize_job(job: dict[str, Any], default_source: str) -> dict[str, Any]:
+    normalized = {field: job.get(field) for field in CORE_FIELDS}
+    normalized.update({k: v for k, v in job.items() if k not in normalized})
+
+    normalized["source"] = normalized.get("source") or default_source
+    normalized["scraped_at"] = normalized.get("scraped_at") or now_utc_iso_seconds()
+
+    if not normalized.get("id"):
+        title = str(normalized.get("title") or "")
+        company = str(normalized.get("company") or normalized["source"] or "")
+        location = str(normalized.get("location") or normalized.get("url") or "")
+        normalized["id"] = build_job_id(title, company, location)
+
+    return normalized
+
+
+def _dedupe_jobs(jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[Any, Any, Any]] = set()
+    deduped: list[dict[str, Any]] = []
+    for job in jobs:
+        key = (job.get("source"), job.get("id"), job.get("url"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(job)
+    return deduped
+
+
+def _parse_scraper_filter(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+
+def _matches_filter(spec: ScraperSpec, filters: set[str]) -> bool:
+    if not filters:
+        return True
+    short_name = spec.module.rsplit(".", 1)[-1].lower()
+    source = spec.source.lower()
+    module = spec.module.lower()
+    return any(item in {short_name, source, module} for item in filters)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Horizons job board scrapers.")
+    parser.add_argument(
+        "--scrapers",
+        help="Comma-separated scraper filter by module short name, full module, or source.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run scrapers and print a summary without writing the output JSON.",
+    )
+    parser.add_argument(
+        "--fail-on-scraper-error",
+        action="store_true",
+        help="Return a non-zero exit code if any individual scraper fails.",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    _configure_logging(args.verbose)
+
+    scraper_filters = _parse_scraper_filter(args.scrapers)
+    scraper_specs = [spec for spec in SCRAPERS if _matches_filter(spec, scraper_filters)]
+    if not scraper_specs:
+        raise SystemExit("No scrapers matched the requested filter.")
+
+    previous = load_previous_jobs()
+    all_jobs: list[dict[str, Any]] = []
+    failures: list[str] = []
+    successful_scrapers = 0
+
+    logger.info("running %s scraper(s)", len(scraper_specs))
+
+    for spec in scraper_specs:
+        try:
+            scraper = import_module(spec.module)
+            fetched = scraper.fetch_jobs()
+            if fetched is None:
+                fetched = []
+            if not isinstance(fetched, list):
+                raise TypeError(f"fetch_jobs() returned {type(fetched).__name__}, expected list")
+
+            source = getattr(scraper, "SOURCE", spec.source)
+            all_jobs.extend(_normalize_job(job, source) for job in fetched if isinstance(job, dict))
+            successful_scrapers += 1
+            logger.info("%s: %s jobs", spec.source, len(fetched))
+        except Exception as exc:
+            failures.append(spec.source)
+            previous_jobs = _previous_jobs_for_source(previous, spec.source)
+            if previous_jobs:
+                all_jobs.extend(
+                    _normalize_job(job, spec.source) for job in previous_jobs if isinstance(job, dict)
+                )
+            exc_text = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+            fallback = f"; kept {len(previous_jobs)} previous jobs" if previous_jobs else ""
+            _warn(f"{spec.source} scraper failed{fallback}: {exc_text}")
+
+    all_jobs = _dedupe_jobs(all_jobs)
     all_jobs.sort(key=lambda j: j["scraped_at"], reverse=True)
 
-    save_latest(all_jobs)
+    if args.dry_run:
+        logger.info("dry run complete: %s jobs collected; output not written", len(all_jobs))
+    else:
+        save_latest(all_jobs)
+        logger.info("wrote %s jobs to %s", len(all_jobs), DATA_PATH)
+
+    if failures:
+        _warn(f"{len(failures)} scraper(s) failed: {', '.join(failures)}")
+
+    if successful_scrapers == 0:
+        raise SystemExit("All scrapers failed; leaving stale fallback data is not enough for a healthy run.")
+
+    if failures and args.fail_on_scraper_error:
+        raise SystemExit(f"{len(failures)} scraper(s) failed: {', '.join(failures)}")
+
+    if not all_jobs:
+        raise SystemExit("No jobs were collected.")
 
 if __name__ == "__main__":
     main()

--- a/scrapers/disco_inc.py
+++ b/scrapers/disco_inc.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urljoin
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 try:
     from datetime import datetime, UTC
@@ -46,6 +46,81 @@ def _clean_text(s: Optional[str]) -> Optional[str]:
         return None
     s = html.unescape(s).replace("\xa0", " ").strip()
     return re.sub(r"\s+", " ", s) or None
+
+
+def _is_striven_job_href(href: Optional[str]) -> bool:
+    return bool(href and "share.striven.com/Job" in href)
+
+
+def _looks_like_non_title(text: str) -> bool:
+    return bool(
+        re.search(
+            r"^(apply|available jobs?|careers?|location|job title|description|view job|learn more)$",
+            text,
+            re.I,
+        )
+    )
+
+
+def _looks_like_location(text: str) -> bool:
+    return bool(re.search(r"\b[A-Z][A-Za-z .'-]+,\s*[A-Z]{2}(?:\s+\d{5})?\b", text))
+
+
+def _extract_location(text: Optional[str]) -> Optional[str]:
+    if not text:
+        return None
+    matches = re.findall(r"\b[A-Z][A-Za-z .'-]+,\s*[A-Z]{2}(?:\s+\d{5})?\b", text)
+    return _clean_text(matches[-1]) if matches else None
+
+
+def _nearest_job_card(anchor: Tag) -> Optional[Tag]:
+    for parent in anchor.parents:
+        if not isinstance(parent, Tag):
+            continue
+        if parent.name not in {"article", "li", "div", "section"}:
+            continue
+        links = parent.find_all("a", href=_is_striven_job_href)
+        text = _clean_text(parent.get_text(" ", strip=True)) or ""
+        if len(links) == 1 and 0 < len(text) < 2000:
+            return parent
+    return None
+
+
+def _last_heading_before_anchor(scope: Tag, anchor: Tag) -> Optional[str]:
+    title: Optional[str] = None
+    for node in scope.descendants:
+        if node is anchor:
+            break
+        if isinstance(node, Tag) and node.name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            text = _clean_text(node.get_text(" ", strip=True))
+            if text and not _looks_like_non_title(text):
+                title = text
+    return title
+
+
+def _title_from_card(card: Optional[Tag], anchor: Tag, soup: BeautifulSoup) -> Optional[str]:
+    if card:
+        heading = card.find(["h1", "h2", "h3", "h4", "h5", "h6"])
+        title = _clean_text(heading.get_text(" ", strip=True)) if heading else None
+        if title and not _looks_like_non_title(title):
+            return title
+
+        for raw in card.stripped_strings:
+            text = _clean_text(raw)
+            if not text or _looks_like_non_title(text) or _looks_like_location(text):
+                continue
+            if text == _clean_text(anchor.get_text(" ", strip=True)):
+                continue
+            return text
+
+    return _last_heading_before_anchor(soup, anchor)
+
+
+def _listing_details_from_anchor(anchor: Tag, soup: BeautifulSoup) -> tuple[Optional[str], Optional[str]]:
+    card = _nearest_job_card(anchor)
+    title = _title_from_card(card, anchor, soup)
+    location = _extract_location(card.get_text(" ", strip=True) if card else None)
+    return title, location
 
 
 def _fetch_striven_job(url: str) -> tuple[Optional[str], Optional[str]]:
@@ -147,7 +222,11 @@ def fetch_jobs() -> List[Dict[str, Optional[str]]]:
         if job_id:
             seen_ids.add(job_id)
 
-        title, location = _fetch_striven_job(job_url)
+        listing_title, listing_location = _listing_details_from_anchor(a, soup)
+        detail_title, detail_location = _fetch_striven_job(job_url)
+
+        title = detail_title or listing_title
+        location = detail_location or listing_location
 
         if not title:
             continue

--- a/scrapers/fmc_board.py
+++ b/scrapers/fmc_board.py
@@ -10,6 +10,12 @@ from bs4 import BeautifulSoup, Tag
 BASE = "https://www.paycomonline.net"
 CLIENT_KEY = "51CCB437D1A5BB8EA54B11A3C07895CA"
 LIST_URL = f"{BASE}/v4/ats/web.php/jobs?clientkey={CLIENT_KEY}"
+PORTAL_URL = f"{BASE}/v4/ats/web.php/portal/{CLIENT_KEY}/career-page"
+PORTAL_JOB_URL = f"{BASE}/v4/ats/web.php/portal/{CLIENT_KEY}/jobs"
+PORTAL_SEARCH_URL = (
+    "https://portal-applicant-tracking.us-cent.paycomonline.net"
+    "/api/ats/job-posting-previews/search"
+)
 DETAIL_PATH = "/v4/ats/web.php/jobs/ViewJobDetails"
 DEFAULT_STATE = "TX"
 
@@ -37,7 +43,7 @@ def _parse_loc_line(text: str) -> Tuple[Optional[str], Optional[str], Optional[s
     dept, place = (p.strip() for p in right.split(" - ", 1)) if " - " in right else (None, right)
 
     city = state = postal = None
-    m = re.search(r"([^,]+),\s*([A-Z]{2})(?:,\s*(\d{5}))?$", place or "")
+    m = re.search(r"([^,]+),\s*([A-Z]{2})(?:[,\s]+(\d{5}))?$", place or "")
     if m:
         city = m.group(1).strip()
         state = m.group(2)
@@ -47,9 +53,13 @@ def _parse_loc_line(text: str) -> Tuple[Optional[str], Optional[str], Optional[s
 
 
 def _extract_job_id(url: str) -> Optional[str]:
-    q = parse_qs(urlparse(url).query)
+    parsed = urlparse(url)
+    q = parse_qs(parsed.query)
     vals = q.get("job")
-    return vals[0] if vals else None
+    if vals:
+        return vals[0]
+    m = re.search(r"/jobs/(\d+)(?:/)?$", parsed.path)
+    return m.group(1) if m else None
 
 
 def _select_list_items(soup: BeautifulSoup):
@@ -121,6 +131,98 @@ def _fetch_detail(session: requests.Session, job_id: str) -> Tuple[Optional[str]
     return title, resp.text
 
 
+def _extract_session_jwt(html: str) -> Optional[str]:
+    m = re.search(r'"sessionJWT"\s*:\s*"([^"]+)"', html or "")
+    return m.group(1) if m else None
+
+
+def _portal_search_payload(skip: int, take: int) -> dict:
+    return {
+        "skip": skip,
+        "take": take,
+        "filtersForQuery": {
+            "distanceFrom": 0,
+            "workEnvironments": [],
+            "positionTypes": [],
+            "educationLevels": [],
+            "categories": [],
+            "travelTypes": [],
+            "shiftTypes": [],
+            "otherFilters": [],
+            "keywordSearchText": "",
+            "location": "",
+            "sortOption": "",
+        },
+    }
+
+
+def _fetch_portal_jobs(session: requests.Session, *, page_size: int = 100) -> List[dict]:
+    resp = session.get(PORTAL_URL, headers=_mk_headers(referer=PORTAL_URL), timeout=25)
+    resp.raise_for_status()
+
+    token = _extract_session_jwt(resp.text)
+    if not token:
+        return []
+
+    headers = _mk_headers(referer=PORTAL_URL)
+    headers.update(
+        {
+            "Authorization": token,
+            "Content-Type": "application/json",
+            "Origin": "https://www.paycomonline.net",
+            "Referer": "https://www.paycomonline.net/",
+        }
+    )
+
+    records: List[dict] = []
+    total: Optional[int] = None
+    skip = 0
+    while total is None or skip < total:
+        api_resp = session.post(
+            PORTAL_SEARCH_URL,
+            headers=headers,
+            json=_portal_search_payload(skip, page_size),
+            timeout=25,
+        )
+        api_resp.raise_for_status()
+        payload = api_resp.json()
+        page_records = payload.get("jobPostingPreviews") or []
+        if total is None:
+            total = int(payload.get("jobPostingPreviewsCount") or len(page_records))
+        if not page_records:
+            break
+        records.extend(page_records)
+        skip += len(page_records)
+        if len(page_records) < page_size:
+            break
+
+    return records
+
+
+def _parse_portal_record(item: dict) -> Dict[str, Optional[str]]:
+    job_id = str(item.get("jobId") or "").strip()
+    title = re.sub(r"\s+", " ", str(item.get("jobTitle") or "")).strip() or None
+    loc_text = re.sub(r"\s+", " ", str(item.get("locations") or "")).strip()
+    _, _, city, state, _, location_raw = _parse_loc_line(loc_text)
+
+    if not (city and state):
+        city_from_title = _extract_city_from_title(title or "")
+        if city_from_title:
+            city, state = city_from_title, DEFAULT_STATE
+            location_raw = f"{city}, {state}"
+
+    return {
+        "id": job_id or None,
+        "title": title,
+        "company": "FMC",
+        "location": _compose_location(city, state, location_raw if loc_text else None),
+        "salary": None,
+        "url": f"{PORTAL_JOB_URL}/{job_id}" if job_id else PORTAL_URL,
+        "scraped_at": _now_utc_iso_seconds(),
+        "source": "FMC",
+    }
+
+
 def _parse_card(session: requests.Session, card: Tag) -> Dict[str, Optional[str]]:
     a = card if getattr(card, "name", None) == "a" else (
         card.select_one("a.JobListing__container[href]") or card.select_one("a[href*='ViewJobDetails']")
@@ -177,6 +279,19 @@ def fetch_jobs(max_pages: int = 10) -> List[Dict[str, Optional[str]]]:
     session = requests.Session()
     out: List[Dict[str, Optional[str]]] = []
     seen_ids: set[str] = set()
+
+    try:
+        for item in _fetch_portal_jobs(session):
+            rec = _parse_portal_record(item)
+            if rec.get("id") and rec["id"] not in seen_ids:
+                out.append(rec)
+                seen_ids.add(rec["id"])
+    except requests.RequestException:
+        out = []
+        seen_ids = set()
+
+    if out:
+        return out
 
     page = 1
     while page <= max_pages:

--- a/scrapers/sage_oil_vac_board.py
+++ b/scrapers/sage_oil_vac_board.py
@@ -17,11 +17,16 @@ except Exception:
 
 COMPANY = "Sage Oil Vac"
 SOURCE = "Sage Oil Vac"
+CLIENT_KEY = "A2551499AF9F0B92169C5FA32A8E8354"
 
 LIST_URL = (
     "https://www.paycomonline.net/v4/ats/web.php/jobs"
-    "?clientkey=A2551499AF9F0B92169C5FA32A8E8354"
+    f"?clientkey={CLIENT_KEY}"
 )
+DETAIL_URL = "https://www.paycomonline.net/v4/ats/web.php/jobs/ViewJobDetails"
+PORTAL_JOB_SELECTOR = f'a[href*="/v4/ats/web.php/portal/{CLIENT_KEY}/jobs/"]'
+LEGACY_JOB_SELECTOR = 'a.JobListing__container, a[href*="ViewJobDetails"]'
+JOB_LINK_SELECTOR = f"{PORTAL_JOB_SELECTOR}, {LEGACY_JOB_SELECTOR}"
 
 
 def _now_utc_iso_seconds() -> str:
@@ -39,7 +44,7 @@ def _extract_job_id(url: str) -> Optional[str]:
         job_ids = qs.get("job")
         if job_ids:
             return job_ids[0]
-        m = re.search(r"/(\d+)(?:/)?$", parsed.path)
+        m = re.search(r"/jobs/(\d+)(?:/)?$", parsed.path)
         if m:
             return m.group(1)
     except Exception:
@@ -70,7 +75,7 @@ def _fetch_location(detail_url: str) -> Optional[str]:
         return None
 
     try:
-        from bs4 import BeautifulSoup 
+        from bs4 import BeautifulSoup
     except Exception:
         return None
 
@@ -81,14 +86,22 @@ def _fetch_location(detail_url: str) -> Optional[str]:
     for i, ln in enumerate(lines):
         if ln == "Job Location" and i + 1 < len(lines):
             return lines[i + 1]
+    m = re.search(r"Job\s+Location\s+(.+?,\s*[A-Z]{2}(?:\s+\d{5})?)", text, re.I)
+    if m:
+        return m.group(1).strip()
     return None
+
+
+def _legacy_detail_url(job_id: str) -> str:
+    return f"{DETAIL_URL}?clientkey={CLIENT_KEY}&job={job_id}"
 
 
 def fetch_jobs() -> List[Dict[str, Optional[str]]]:
     jobs: List[Dict[str, Optional[str]]] = []
+    seen_ids: set[str] = set()
 
     with sync_playwright() as p:
-        browser = p.chromium.launch(headless=True)
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
         ctx = browser.new_context(
             user_agent=(
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -107,17 +120,18 @@ def fetch_jobs() -> List[Dict[str, Optional[str]]]:
 
 
         try:
-            page.wait_for_selector("li.jobInfo.JobListing, li.JobListing", timeout=20000)
+            page.wait_for_selector(JOB_LINK_SELECTOR, timeout=20000)
         except PWTimeout:
             browser.close()
             return []
 
         rows = page.eval_on_selector_all(
-            "li.jobInfo.JobListing, li.JobListing",
-            """els => els.map(li => {
-                const a = li.querySelector('a.JobListing__container, a[href*="ViewJobDetails"]');
-                const titleSpan = li.querySelector('.jobTitle') || a;
-                const descrSpan = li.querySelector('.jobDescription');
+            JOB_LINK_SELECTOR,
+            """els => els.map(a => {
+                const card = a.closest('li, article, div[data-testid], div') || a;
+                const titleSpan = card.querySelector('h2[data-testid="typography"], h2, .jobTitle, [class*="jobTitle"]') || a;
+                const pEls = Array.from(card.querySelectorAll('p[data-testid="typography"], p'));
+                const legacyDescrSpan = card.querySelector('.jobDescription, .JobListing__subTitle, [class*="jobLocation"]');
                 const href = a ? (a.getAttribute('href') || '') : '';
                 let url = href;
                 try {
@@ -126,7 +140,8 @@ def fetch_jobs() -> List[Dict[str, Optional[str]]]:
                 return {
                     title: titleSpan ? titleSpan.textContent.trim() : '',
                     url,
-                    summary: descrSpan ? descrSpan.textContent.trim() : ''
+                    location: pEls.length > 0 ? pEls[0].textContent.trim() : '',
+                    summary: legacyDescrSpan ? legacyDescrSpan.textContent.trim() : ''
                 };
             })"""
         )
@@ -139,9 +154,15 @@ def fetch_jobs() -> List[Dict[str, Optional[str]]]:
         if not title or not url:
             continue
 
-        job_id = _extract_job_id(url) or title[:90]
+        extracted_job_id = _extract_job_id(url)
+        job_id = extracted_job_id or title[:90]
+        if job_id in seen_ids:
+            continue
+        seen_ids.add(job_id)
 
-        location = _fetch_location(url)
+        location = (row.get("location") or "").strip() or None
+        if not location and extracted_job_id:
+            location = _fetch_location(_legacy_detail_url(extracted_job_id))
 
         jobs.append(
             {

--- a/scrapers/western_equipment.py
+++ b/scrapers/western_equipment.py
@@ -5,6 +5,7 @@ import re
 from typing import Dict, List, Optional
 from urllib.parse import urlparse, parse_qs
 
+import requests
 from playwright.sync_api import sync_playwright, TimeoutError as PWTimeout
 
 try:
@@ -16,10 +17,23 @@ except Exception:  # Python < 3.11
 
 COMPANY = "Western Equipment"
 SOURCE = "Western Equipment"
+CLIENT_KEY = "BEC705AAE8346DB92E3A5C60250EE84C"
 
 LIST_URL = (
     "https://www.paycomonline.net/v4/ats/web.php/jobs"
-    "?clientkey=BEC705AAE8346DB92E3A5C60250EE84C"
+    f"?clientkey={CLIENT_KEY}"
+)
+PORTAL_URL = (
+    "https://www.paycomonline.net/v4/ats/web.php/portal"
+    f"/{CLIENT_KEY}/career-page"
+)
+PORTAL_JOB_URL = (
+    "https://www.paycomonline.net/v4/ats/web.php/portal"
+    f"/{CLIENT_KEY}/jobs"
+)
+PORTAL_SEARCH_URL = (
+    "https://portal-applicant-tracking.us-cent.paycomonline.net"
+    "/api/ats/job-posting-previews/search"
 )
 
 
@@ -46,8 +60,120 @@ def _extract_job_id(url: str) -> Optional[str]:
     return None
 
 
+def _mk_headers(referer: str = PORTAL_URL) -> Dict[str, str]:
+    return {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/125.0.0.0 Safari/537.36"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+        "Referer": referer,
+    }
+
+
+def _extract_session_jwt(html: str) -> Optional[str]:
+    m = re.search(r'"sessionJWT"\s*:\s*"([^"]+)"', html or "")
+    return m.group(1) if m else None
+
+
+def _portal_search_payload(skip: int, take: int) -> dict:
+    return {
+        "skip": skip,
+        "take": take,
+        "filtersForQuery": {
+            "distanceFrom": 0,
+            "workEnvironments": [],
+            "positionTypes": [],
+            "educationLevels": [],
+            "categories": [],
+            "travelTypes": [],
+            "shiftTypes": [],
+            "otherFilters": [],
+            "keywordSearchText": "",
+            "location": "",
+            "sortOption": "",
+        },
+    }
+
+
+def _fetch_portal_jobs(session: requests.Session, *, page_size: int = 100) -> List[dict]:
+    resp = session.get(PORTAL_URL, headers=_mk_headers(), timeout=25)
+    resp.raise_for_status()
+
+    token = _extract_session_jwt(resp.text)
+    if not token:
+        return []
+
+    headers = _mk_headers(referer=PORTAL_URL)
+    headers.update(
+        {
+            "Authorization": token,
+            "Content-Type": "application/json",
+            "Origin": "https://www.paycomonline.net",
+            "Referer": "https://www.paycomonline.net/",
+        }
+    )
+
+    records: List[dict] = []
+    total: Optional[int] = None
+    skip = 0
+    while total is None or skip < total:
+        api_resp = session.post(
+            PORTAL_SEARCH_URL,
+            headers=headers,
+            json=_portal_search_payload(skip, page_size),
+            timeout=25,
+        )
+        api_resp.raise_for_status()
+        payload = api_resp.json()
+        page_records = payload.get("jobPostingPreviews") or []
+        if total is None:
+            total = int(payload.get("jobPostingPreviewsCount") or len(page_records))
+        if not page_records:
+            break
+        records.extend(page_records)
+        skip += len(page_records)
+        if len(page_records) < page_size:
+            break
+
+    return records
+
+
+def _parse_portal_record(item: dict) -> Dict[str, Optional[str]]:
+    job_id = str(item.get("jobId") or "").strip()
+    title = re.sub(r"\s+", " ", str(item.get("jobTitle") or "")).strip() or None
+    location = re.sub(r"\s+", " ", str(item.get("locations") or "")).strip() or None
+
+    return {
+        "id": job_id or None,
+        "title": title,
+        "company": COMPANY,
+        "location": location,
+        "salary": None,
+        "url": f"{PORTAL_JOB_URL}/{job_id}" if job_id else PORTAL_URL,
+        "scraped_at": _now_utc_iso_seconds(),
+        "source": SOURCE,
+    }
+
+
 def fetch_jobs() -> List[Dict[str, Optional[str]]]:
     jobs: List[Dict[str, Optional[str]]] = []
+    seen_ids: set[str] = set()
+
+    session = requests.Session()
+    try:
+        for item in _fetch_portal_jobs(session):
+            rec = _parse_portal_record(item)
+            if rec.get("id") and rec["id"] not in seen_ids:
+                jobs.append(rec)
+                seen_ids.add(rec["id"])
+    except requests.RequestException:
+        jobs = []
+        seen_ids = set()
+
+    if jobs:
+        return jobs
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
@@ -69,9 +195,7 @@ def fetch_jobs() -> List[Dict[str, Optional[str]]]:
         except Exception:
             pass
 
-        selector = (
-            'a[href*="/v4/ats/web.php/portal/BEC705AAE8346DB92E3A5C60250EE84C/jobs/"]'
-        )
+        selector = f'a[href*="/v4/ats/web.php/portal/{CLIENT_KEY}/jobs/"]'
         try:
             page.wait_for_selector(selector, timeout=20000)
         except PWTimeout:
@@ -109,6 +233,9 @@ def fetch_jobs() -> List[Dict[str, Optional[str]]]:
             continue
 
         job_id = _extract_job_id(url) or title[:90]
+        if job_id in seen_ids:
+            continue
+        seen_ids.add(job_id)
 
         jobs.append(
             {

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,40 @@
-import hashlib, json, pathlib
+import hashlib
+import json
+import os
+import pathlib
 
-DATA_PATH = pathlib.Path("data/latest_jobs.json")
-DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+try:
+    from datetime import datetime, UTC
+except Exception:
+    from datetime import datetime, timezone as _tz
+    UTC = _tz.utc
+
+DATA_PATH = pathlib.Path(
+    os.environ.get("JOB_DATA_PATH") or os.environ.get("OUTPUT_PATH") or "data/latest_jobs.json"
+)
 
 
 def build_job_id(title: str, company: str, location: str) -> str:
     key = f"{title}|{company}|{location}"
     return hashlib.sha1(key.encode()).hexdigest()
 
+
+def now_utc_iso_seconds() -> str:
+    return datetime.now(UTC).replace(tzinfo=None).isoformat(timespec="seconds")
+
+
+def load_previous_jobs() -> list[dict]:
+    if DATA_PATH.exists():
+        return json.loads(DATA_PATH.read_text())
+    return []
+
+
 def load_previous() -> dict[str, dict]:
     if DATA_PATH.exists():
-        return {item["id"]: item for item in json.loads(DATA_PATH.read_text())}
+        return {item["id"]: item for item in load_previous_jobs()}
     return {}
 
+
 def save_latest(jobs: list[dict]) -> None:
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
     DATA_PATH.write_text(json.dumps(jobs, indent=2, ensure_ascii=False))


### PR DESCRIPTION
## Summary

- Make `run_scrapers.py` resilient to individual scraper failures, with warning output, fallback to prior source data when available, scraper filtering, dry runs, and stricter opt-in failure behavior.
- Restore and harden the DISCO scraper, update FMC/Sage/Western Paycom handling for the current portal layout, and add environment-configurable output paths for an eventual container/GCP runtime.
- Add a scraper-focused Docker image, `.dockerignore`, `.gitignore`, bounded requirements, and a container smoke-test workflow.

## Validation

- `git diff --check`
- `docker build -t horizons-aggregator .`
- `docker run --rm horizons-aggregator python run_scrapers.py --help`
- `docker run --rm horizons-aggregator python -m compileall run_scrapers.py utils.py scrapers app`
- Full container scraper run wrote 139 jobs locally.
- Live count gutcheck matched every source: WTAMU 26, TTUHSC 21, FMC 18, Amarillo National Bank 13, Yellowhouse 10, Austin Hose 10, Sage Oil Vac 5, Talon/LPE 9, Western Equipment 24, DISCO 3.

## Note

The generated `data/latest_jobs.json` was validated locally, but this PR keeps the commit focused on scraper/runtime code and leaves the data artifact to be regenerated by the fixed runner.